### PR TITLE
Align filter chips and stats cards with web design

### DIFF
--- a/src/components/AllTasksView.js
+++ b/src/components/AllTasksView.js
@@ -171,8 +171,9 @@ export default function AllTasksView({
 
       {/* Filter Chips */}
       <FilterChips
-        selected={selectedFilter}
-        onSelect={setSelectedFilter}
+        tasks={tasks}
+        selectedFilter={selectedFilter}
+        onFilterChange={setSelectedFilter}
         filters={[
           { id: 'all', label: currentLanguage === 'zh' ? '全部' : 'All' },
           { id: 'pending', label: currentLanguage === 'zh' ? '进行中' : 'Pending' },

--- a/src/components/EventBookDetail.js
+++ b/src/components/EventBookDetail.js
@@ -190,8 +190,9 @@ export default function EventBookDetail({
 
       {/* Filter Chips */}
       <FilterChips
-        selected={selectedFilter}
-        onSelect={setSelectedFilter}
+        tasks={tasks}
+        selectedFilter={selectedFilter}
+        onFilterChange={setSelectedFilter}
         filters={[
           { id: 'all', label: currentLanguage === 'zh' ? '全部' : 'All' },
           { id: 'pending', label: currentLanguage === 'zh' ? '进行中' : 'Pending' },

--- a/src/components/EventBooksList.js
+++ b/src/components/EventBooksList.js
@@ -21,14 +21,14 @@ const scale = (size) => (screenWidth / 375) * size;
 const verticalScale = (size) => (screenHeight / 812) * size;
 const moderateScale = (size, factor = 0.5) => size + (scale(size) - size) * factor;
 
-export default function EventBooksList({ 
-  onSelectBook, 
-  onCreateBook, 
-  onSettingsClick, 
+export default function EventBooksList({
+  onSelectBook,
+  onCreateBook,
+  onSettingsClick,
   onViewAllTasks,
-  navigation 
+  navigation
 }) {
-  const { theme } = useTheme();
+  const { theme } = useThemeContext();
   const { t, currentLanguage } = useLanguage();
   
   // Create localized event books data

--- a/src/components/FilterChips.js
+++ b/src/components/FilterChips.js
@@ -2,25 +2,112 @@ import React from 'react';
 import { View, Text, TouchableOpacity, ScrollView, StyleSheet } from 'react-native';
 import { useThemeContext } from '../context/ThemeContext';
 
-export default function FilterChips({ tasks = [], selectedFilter, onFilterChange }) {
-  const { theme } = useThemeContext();
-  
-  const getTaskCount = (filter) => {
-    if (filter === 'all') return tasks.length;
-    return tasks.filter(task => task.category === filter).length;
-  };
+const PRIORITY_FILTERS = new Set(['high', 'medium', 'low']);
 
-  const filterOptions = [
-    { id: 'all', label: '全部', count: getTaskCount('all') },
-    { id: 'completed', label: '已完成', count: getTaskCount('completed') },
-    { id: 'pending', label: '未完成', count: getTaskCount('pending') },
-    { id: 'overdue', label: '逾期', count: getTaskCount('overdue') },
-    { id: 'csc3', label: 'CSC3', count: getTaskCount('csc3') }
-  ];
-  
+const FILTER_LABELS = {
+  all: '全部',
+  pending: '进行中',
+  completed: '已完成',
+  overdue: '逾期',
+  csc3: 'CSC3',
+};
+
+const SYSTEM_FILTER_ORDER = ['pending', 'completed', 'overdue'];
+const CUSTOM_FILTER_ORDER = ['csc3'];
+
+const getLabelForFilter = (filterId) => FILTER_LABELS[filterId] || filterId;
+
+const buildFiltersFromTasks = (tasks) => {
+  if (!Array.isArray(tasks) || tasks.length === 0) {
+    return [{ id: 'all', label: getLabelForFilter('all') }];
+  }
+
+  const categoriesInTasks = new Set(
+    tasks
+      .map((task) => task?.category)
+      .filter((category) => typeof category === 'string' && category.length > 0)
+  );
+
+  const filters = [{ id: 'all', label: getLabelForFilter('all') }];
+
+  SYSTEM_FILTER_ORDER.forEach((filterId) => {
+    if (categoriesInTasks.has(filterId)) {
+      filters.push({ id: filterId, label: getLabelForFilter(filterId) });
+    }
+  });
+
+  CUSTOM_FILTER_ORDER.forEach((filterId) => {
+    if (categoriesInTasks.has(filterId)) {
+      filters.push({ id: filterId, label: getLabelForFilter(filterId) });
+    }
+  });
+
+  categoriesInTasks.forEach((category) => {
+    if (!filters.some((filter) => filter.id === category)) {
+      filters.push({ id: category, label: getLabelForFilter(category) });
+    }
+  });
+
+  return filters;
+};
+
+const computeCount = (tasks, filterId) => {
+  if (!Array.isArray(tasks) || tasks.length === 0) {
+    return 0;
+  }
+
+  if (filterId === 'all') {
+    return tasks.length;
+  }
+
+  if (filterId === 'overdue') {
+    return tasks.filter(task => {
+      if (task.category === 'overdue') {
+        return true;
+      }
+
+      if (!task.deadline || task.category === 'completed') {
+        return false;
+      }
+
+      const dueDate = new Date(task.deadline);
+      return !Number.isNaN(dueDate.getTime()) && dueDate < new Date();
+    }).length;
+  }
+
+  if (PRIORITY_FILTERS.has(filterId)) {
+    return tasks.filter(task => task.priority === filterId).length;
+  }
+
+  return tasks.filter(task => task.category === filterId).length;
+};
+
+export default function FilterChips({
+  tasks = [],
+  filters,
+  selectedFilter,
+  selected,
+  onFilterChange,
+  onSelect
+}) {
+  const { theme } = useThemeContext();
+
+  const activeFilter = selectedFilter ?? selected ?? 'all';
+  const handleChange = onFilterChange ?? onSelect;
+
+  const providedFilters = Array.isArray(filters) && filters.length > 0
+    ? filters
+    : buildFiltersFromTasks(tasks);
+
+  const filterOptions = providedFilters.map((option) => ({
+    ...option,
+    label: option.label ?? getLabelForFilter(option.id),
+    count: option.count ?? computeCount(tasks, option.id),
+  }));
+
   return (
-    <ScrollView 
-      horizontal 
+    <ScrollView
+      horizontal
       showsHorizontalScrollIndicator={false}
       contentContainerStyle={styles.container}
       style={styles.scrollView}
@@ -28,51 +115,58 @@ export default function FilterChips({ tasks = [], selectedFilter, onFilterChange
       {filterOptions.map((option) => (
         <TouchableOpacity
           key={option.id}
-          onPress={() => onFilterChange(option.id)}
+          onPress={() => handleChange && handleChange(option.id)}
           style={[
             styles.filterChip,
             {
-              backgroundColor: selectedFilter === option.id 
-                ? theme.colors.primary + '20' 
-                : theme.colors.card,
-              borderColor: selectedFilter === option.id 
-                ? theme.colors.primary 
-                : theme.colors.cardBorder || theme.colors.border,
-              borderWidth: selectedFilter === option.id ? 2 : 1,
-            }
+              backgroundColor:
+                activeFilter === option.id
+                  ? theme.colors.primary + '20'
+                  : theme.colors.card,
+              borderColor:
+                activeFilter === option.id
+                  ? theme.colors.primary
+                  : theme.colors.cardBorder || theme.colors.border,
+              borderWidth: activeFilter === option.id ? 2 : 1,
+              opacity: handleChange ? 1 : 0.6,
+            },
           ]}
           activeOpacity={0.7}
+          disabled={!handleChange}
         >
-          <Text 
+          <Text
             style={[
               styles.filterLabel,
               {
-                color: selectedFilter === option.id 
-                  ? theme.colors.primary 
-                  : theme.colors.mutedForeground || theme.colors.text,
-              }
+                color:
+                  activeFilter === option.id
+                    ? theme.colors.primary
+                    : theme.colors.mutedForeground || theme.colors.text,
+              },
             ]}
           >
             {option.label}
           </Text>
-          <View 
+          <View
             style={[
               styles.countBadge,
               {
-                backgroundColor: selectedFilter === option.id 
-                  ? theme.colors.primary + '30' 
-                  : theme.colors.cardBorder || theme.colors.border,
-              }
+                backgroundColor:
+                  activeFilter === option.id
+                    ? theme.colors.primary + '30'
+                    : theme.colors.cardBorder || theme.colors.border,
+              },
             ]}
           >
-            <Text 
+            <Text
               style={[
                 styles.countText,
                 {
-                  color: selectedFilter === option.id 
-                    ? theme.colors.primary 
-                    : theme.colors.mutedForeground || theme.colors.text,
-                }
+                  color:
+                    activeFilter === option.id
+                      ? theme.colors.primary
+                      : theme.colors.mutedForeground || theme.colors.text,
+                },
               ]}
             >
               {option.count}
@@ -91,26 +185,31 @@ const styles = StyleSheet.create({
   },
   container: {
     flexDirection: 'row',
-    gap: 8,
+    alignItems: 'center',
+    paddingHorizontal: 4,
+    columnGap: 12,
+    rowGap: 12,
   },
   filterChip: {
     flexDirection: 'row',
     alignItems: 'center',
-    gap: 8,
-    paddingHorizontal: 16,
-    paddingVertical: 8,
-    borderRadius: 12,
+    gap: 10,
+    paddingHorizontal: 18,
+    paddingVertical: 12,
+    borderRadius: 24,
     borderWidth: 1,
   },
   filterLabel: {
     fontSize: 14,
+    fontWeight: '600',
   },
   countBadge: {
     paddingHorizontal: 8,
-    paddingVertical: 2,
-    borderRadius: 8,
+    paddingVertical: 4,
+    borderRadius: 12,
   },
   countText: {
     fontSize: 12,
+    fontWeight: '600',
   },
 });

--- a/src/components/FilterChips.js
+++ b/src/components/FilterChips.js
@@ -82,18 +82,19 @@ const computeCount = (tasks, filterId) => {
   return tasks.filter(task => task.category === filterId).length;
 };
 
-export default function FilterChips({
+const FilterChipsComponent = ({
   tasks = [],
   filters,
   selectedFilter,
   selected,
   onFilterChange,
-  onSelect
-}) {
+  onSelect,
+}) => {
   const { theme } = useThemeContext();
 
   const activeFilter = selectedFilter ?? selected ?? 'all';
   const handleChange = onFilterChange ?? onSelect;
+  const borderColor = theme.colors.cardBorder || theme.colors.border;
 
   const providedFilters = Array.isArray(filters) && filters.length > 0
     ? filters
@@ -126,7 +127,7 @@ export default function FilterChips({
               borderColor:
                 activeFilter === option.id
                   ? theme.colors.primary
-                  : theme.colors.cardBorder || theme.colors.border,
+                  : borderColor,
               borderWidth: activeFilter === option.id ? 2 : 1,
               opacity: handleChange ? 1 : 0.6,
             },
@@ -154,7 +155,7 @@ export default function FilterChips({
                 backgroundColor:
                   activeFilter === option.id
                     ? theme.colors.primary + '30'
-                    : theme.colors.cardBorder || theme.colors.border,
+                    : borderColor,
               },
             ]}
           >
@@ -176,7 +177,11 @@ export default function FilterChips({
       ))}
     </ScrollView>
   );
-}
+};
+
+export const FilterChips = FilterChipsComponent;
+
+export default FilterChipsComponent;
 
 const styles = StyleSheet.create({
   scrollView: {

--- a/src/components/FilterChips.tsx
+++ b/src/components/FilterChips.tsx
@@ -2,135 +2,243 @@ import React from 'react';
 import { View, Text, TouchableOpacity, ScrollView, StyleSheet } from 'react-native';
 import { useThemeContext } from '../context/ThemeContext';
 
+type FilterId = string;
+
+type TaskPriority = 'high' | 'medium' | 'low' | string;
+
+type TaskCategory = 'all' | 'completed' | 'pending' | 'overdue' | 'csc3' | string;
+
 interface Task {
   id: string;
-  countdown: string;
-  deadline?: string;
-  title: string;
-  description: string;
-  folderColor: string;
-  type: '一次性' | '循环';
-  duration?: string;
-  priority?: 'high' | 'medium' | 'low';
-  category?: string;
+  category?: TaskCategory;
+  deadline?: string | Date;
+  priority?: TaskPriority;
 }
 
-type FilterType = 'all' | 'completed' | 'pending' | 'overdue' | 'csc3';
+interface FilterOption {
+  id: FilterId;
+  label?: string;
+  count?: number;
+}
 
 interface FilterChipsProps {
-  tasks: Task[];
-  selectedFilter: FilterType;
-  onFilterChange: (filter: FilterType) => void;
+  tasks?: Task[];
+  filters?: FilterOption[];
+  selectedFilter?: FilterId;
+  selected?: FilterId;
+  onFilterChange?: (filter: FilterId) => void;
+  onSelect?: (filter: FilterId) => void;
 }
 
-export function FilterChips({ tasks, selectedFilter, onFilterChange }: FilterChipsProps) {
-  const { theme } = useThemeContext();
-  
-  const getTaskCount = (filter: FilterType) => {
-    if (filter === 'all') return tasks.length;
-    return tasks.filter(task => task.category === filter).length;
-  };
+const PRIORITY_FILTERS = new Set<FilterId>(['high', 'medium', 'low']);
 
-  const filterOptions = [
-    { id: 'all' as FilterType, label: '全部', count: getTaskCount('all') },
-    { id: 'completed' as FilterType, label: '已完成', count: getTaskCount('completed') },
-    { id: 'pending' as FilterType, label: '未完成', count: getTaskCount('pending') },
-    { id: 'overdue' as FilterType, label: '逾期', count: getTaskCount('overdue') },
-    { id: 'csc3' as FilterType, label: 'CSC3', count: getTaskCount('csc3') }
-  ];
-  
+const FILTER_LABELS: Record<string, string> = {
+  all: '全部',
+  pending: '进行中',
+  completed: '已完成',
+  overdue: '逾期',
+  csc3: 'CSC3',
+};
+
+const SYSTEM_FILTER_ORDER: FilterId[] = ['pending', 'completed', 'overdue'];
+const CUSTOM_FILTER_ORDER: FilterId[] = ['csc3'];
+
+const getLabelForFilter = (filterId: FilterId) => FILTER_LABELS[filterId] ?? filterId;
+
+const buildFiltersFromTasks = (tasks: Task[] = []): FilterOption[] => {
+  if (!Array.isArray(tasks) || tasks.length === 0) {
+    return [{ id: 'all', label: getLabelForFilter('all') }];
+  }
+
+  const categoriesInTasks = new Set(
+    tasks
+      .map((task) => task?.category)
+      .filter((category): category is string => Boolean(category && category.length > 0))
+  );
+
+  const filters: FilterOption[] = [{ id: 'all', label: getLabelForFilter('all') }];
+
+  SYSTEM_FILTER_ORDER.forEach((filterId) => {
+    if (categoriesInTasks.has(filterId)) {
+      filters.push({ id: filterId, label: getLabelForFilter(filterId) });
+    }
+  });
+
+  CUSTOM_FILTER_ORDER.forEach((filterId) => {
+    if (categoriesInTasks.has(filterId)) {
+      filters.push({ id: filterId, label: getLabelForFilter(filterId) });
+    }
+  });
+
+  categoriesInTasks.forEach((category) => {
+    if (!filters.some((filter) => filter.id === category)) {
+      filters.push({ id: category, label: getLabelForFilter(category) });
+    }
+  });
+
+  return filters;
+};
+
+const computeCount = (tasks: Task[] = [], filterId: FilterId): number => {
+  if (!Array.isArray(tasks) || tasks.length === 0) {
+    return 0;
+  }
+
+  if (filterId === 'all') {
+    return tasks.length;
+  }
+
+  if (filterId === 'overdue') {
+    return tasks.filter((task) => {
+      if (task.category === 'overdue') {
+        return true;
+      }
+
+      if (!task.deadline || task.category === 'completed') {
+        return false;
+      }
+
+      const dueDate = new Date(task.deadline);
+      return !Number.isNaN(dueDate.getTime()) && dueDate < new Date();
+    }).length;
+  }
+
+  if (PRIORITY_FILTERS.has(filterId)) {
+    return tasks.filter((task) => task.priority === filterId).length;
+  }
+
+  return tasks.filter((task) => task.category === filterId).length;
+};
+
+const FilterChipsComponent: React.FC<FilterChipsProps> = ({
+  tasks = [],
+  filters,
+  selectedFilter,
+  selected,
+  onFilterChange,
+  onSelect,
+}) => {
+  const { theme } = useThemeContext();
+
+  const activeFilter = selectedFilter ?? selected ?? 'all';
+  const handleChange = onFilterChange ?? onSelect;
+  const borderColor = theme.colors.cardBorder ?? theme.colors.border;
+
+  const providedFilters = Array.isArray(filters) && filters.length > 0
+    ? filters
+    : buildFiltersFromTasks(tasks);
+
+  const filterOptions = providedFilters.map((option) => ({
+    ...option,
+    label: option.label ?? getLabelForFilter(option.id),
+    count: option.count ?? computeCount(tasks, option.id),
+  }));
+
   return (
-    <ScrollView 
-      horizontal 
+    <ScrollView
+      horizontal
       showsHorizontalScrollIndicator={false}
       contentContainerStyle={styles.container}
       style={styles.scrollView}
     >
-      {filterOptions.map((option) => (
-        <TouchableOpacity
-          key={option.id}
-          onPress={() => onFilterChange(option.id)}
-          style={[
+      {filterOptions.map((option) => {
+        const isActive = activeFilter === option.id;
+        return (
+          <TouchableOpacity
+            key={option.id}
+            onPress={() => handleChange && handleChange(option.id)}
+            style={[
             styles.filterChip,
             {
-              backgroundColor: selectedFilter === option.id 
-                ? theme.colors.primary + '20' 
+              backgroundColor: isActive
+                ? `${theme.colors.primary}20`
                 : theme.colors.card,
-              borderColor: selectedFilter === option.id 
-                ? theme.colors.primary 
-                : theme.colors.cardBorder,
-              borderWidth: selectedFilter === option.id ? 2 : 1,
-            }
+              borderColor: isActive ? theme.colors.primary : borderColor,
+              borderWidth: isActive ? 2 : 1,
+              opacity: handleChange ? 1 : 0.6,
+            },
           ]}
-          activeOpacity={0.7}
-        >
-          <Text 
-            style={[
-              styles.filterLabel,
-              {
-                color: selectedFilter === option.id 
-                  ? theme.colors.primary 
-                  : theme.colors.mutedForeground,
-              }
-            ]}
+            activeOpacity={0.7}
+            disabled={!handleChange}
           >
-            {option.label}
-          </Text>
-          <View 
-            style={[
-              styles.countBadge,
-              {
-                backgroundColor: selectedFilter === option.id 
-                  ? theme.colors.primary + '30' 
-                  : theme.colors.cardBorder,
-              }
-            ]}
-          >
-            <Text 
+            <Text
               style={[
-                styles.countText,
+                styles.filterLabel,
                 {
-                  color: selectedFilter === option.id 
-                    ? theme.colors.primary 
-                    : theme.colors.mutedForeground,
-                }
+                  color: isActive
+                    ? theme.colors.primary
+                    : theme.colors.mutedForeground ?? theme.colors.text,
+                },
               ]}
             >
-              {option.count}
+              {option.label}
             </Text>
-          </View>
-        </TouchableOpacity>
-      ))}
+            <View
+              style={[
+                styles.countBadge,
+                {
+                  backgroundColor: isActive
+                    ? `${theme.colors.primary}30`
+                    : borderColor,
+                },
+              ]}
+            >
+              <Text
+                style={[
+                  styles.countText,
+                  {
+                    color: isActive
+                      ? theme.colors.primary
+                      : theme.colors.mutedForeground ?? theme.colors.text,
+                  },
+                ]}
+              >
+                {option.count}
+              </Text>
+            </View>
+          </TouchableOpacity>
+        );
+      })}
     </ScrollView>
   );
-}
+};
+
+export const FilterChips = FilterChipsComponent;
+
+export default FilterChipsComponent;
 
 const styles = StyleSheet.create({
   scrollView: {
     paddingBottom: 8,
+    marginBottom: 16,
   },
   container: {
     flexDirection: 'row',
-    gap: 8,
+    alignItems: 'center',
+    paddingHorizontal: 4,
+    columnGap: 12,
+    rowGap: 12,
   },
   filterChip: {
     flexDirection: 'row',
     alignItems: 'center',
-    gap: 8,
-    paddingHorizontal: 16,
-    paddingVertical: 8,
-    borderRadius: 12,
+    gap: 10,
+    paddingHorizontal: 18,
+    paddingVertical: 12,
+    borderRadius: 24,
     borderWidth: 1,
   },
   filterLabel: {
     fontSize: 14,
+    fontWeight: '600',
   },
   countBadge: {
     paddingHorizontal: 8,
-    paddingVertical: 2,
-    borderRadius: 8,
+    paddingVertical: 4,
+    borderRadius: 12,
   },
   countText: {
     fontSize: 12,
+    fontWeight: '600',
   },
 });

--- a/src/components/StatsCards.js
+++ b/src/components/StatsCards.js
@@ -4,7 +4,7 @@ import { Ionicons } from '@expo/vector-icons';
 import { useThemeContext } from '../context/ThemeContext';
 
 const getTaskMetrics = (tasks = []) => {
-  if (!Array.isArray(tasks)) {
+  if (!Array.isArray(tasks) || tasks.length === 0) {
     return {
       total: 0,
       pending: 0,
@@ -55,10 +55,13 @@ const getTaskMetrics = (tasks = []) => {
   };
 };
 
-export default function StatsCards({ tasks = [] }) {
+const StatsCardsComponent = ({ tasks = [] }) => {
   const { theme } = useThemeContext();
 
   const metrics = useMemo(() => getTaskMetrics(tasks), [tasks]);
+  const borderColor = theme.colors.cardBorder || theme.colors.border;
+  const successColor = theme.colors.success || '#10B981';
+  const destructiveColor = theme.colors.destructive || '#EF4444';
 
   const statsData = [
     {
@@ -104,7 +107,7 @@ export default function StatsCards({ tasks = [] }) {
             styles.card,
             {
               backgroundColor: theme.colors.card,
-              borderColor: theme.colors.cardBorder || theme.colors.border,
+              borderColor,
             }
           ]}
         >
@@ -128,8 +131,8 @@ export default function StatsCards({ tasks = [] }) {
                 styles.trendContainer,
                 {
                   backgroundColor: stat.trendUp
-                    ? (theme.colors.success || '#10B981') + '20'
-                    : (theme.colors.destructive || '#EF4444') + '20',
+                    ? successColor + '20'
+                    : destructiveColor + '20',
                 }
               ]}
             >
@@ -138,8 +141,8 @@ export default function StatsCards({ tasks = [] }) {
                   styles.trendText,
                   {
                     color: stat.trendUp
-                      ? (theme.colors.success || '#10B981')
-                      : (theme.colors.destructive || '#EF4444'),
+                      ? successColor
+                      : destructiveColor,
                   }
                 ]}
               >
@@ -170,7 +173,11 @@ export default function StatsCards({ tasks = [] }) {
       ))}
     </View>
   );
-}
+};
+
+export const StatsCards = StatsCardsComponent;
+
+export default StatsCardsComponent;
 
 const styles = StyleSheet.create({
   container: {

--- a/src/components/StatsCards.js
+++ b/src/components/StatsCards.js
@@ -1,46 +1,100 @@
-import React from 'react';
+import React, { useMemo } from 'react';
 import { View, Text, StyleSheet } from 'react-native';
 import { Ionicons } from '@expo/vector-icons';
 import { useThemeContext } from '../context/ThemeContext';
 
-const statsData = [
-  {
-    id: 'pending',
-    label: '进行中',
-    value: '8',
-    icon: 'time-outline',
-    trend: '+2',
-    trendUp: true
-  },
-  {
-    id: 'completed',
-    label: '已完成',
-    value: '24',
-    icon: 'checkmark-circle-outline',
-    trend: '+5',
-    trendUp: true
-  },
-  {
-    id: 'overdue',
-    label: '逾期',
-    value: '2',
-    icon: 'alert-circle-outline',
-    trend: '-1',
-    trendUp: false
-  },
-  {
-    id: 'efficiency',
-    label: '效率',
-    value: '92%',
-    icon: 'trending-up-outline',
-    trend: '+8%',
-    trendUp: true
+const getTaskMetrics = (tasks = []) => {
+  if (!Array.isArray(tasks)) {
+    return {
+      total: 0,
+      pending: 0,
+      completed: 0,
+      overdue: 0,
+      efficiency: 0,
+    };
   }
-];
 
-export default function StatsCards() {
+  const now = new Date();
+
+  const metrics = tasks.reduce((acc, task) => {
+    const category = task.category;
+
+    if (category === 'completed') {
+      acc.completed += 1;
+    } else if (category === 'pending') {
+      acc.pending += 1;
+    }
+
+    const isOverdue = (() => {
+      if (category === 'overdue') {
+        return true;
+      }
+      if (!task.deadline || category === 'completed') {
+        return false;
+      }
+      const deadlineDate = new Date(task.deadline);
+      return !Number.isNaN(deadlineDate.getTime()) && deadlineDate < now;
+    })();
+
+    if (isOverdue) {
+      acc.overdue += 1;
+    }
+
+    return acc;
+  }, { pending: 0, completed: 0, overdue: 0 });
+
+  const total = tasks.length;
+  const efficiency = total > 0 ? Math.round((metrics.completed / total) * 100) : 0;
+
+  return {
+    total,
+    pending: metrics.pending,
+    completed: metrics.completed,
+    overdue: metrics.overdue,
+    efficiency,
+  };
+};
+
+export default function StatsCards({ tasks = [] }) {
   const { theme } = useThemeContext();
-  
+
+  const metrics = useMemo(() => getTaskMetrics(tasks), [tasks]);
+
+  const statsData = [
+    {
+      id: 'pending',
+      label: '进行中',
+      value: String(metrics.pending),
+      icon: 'time-outline',
+      trend: metrics.total > 0 ? `+${metrics.pending}` : '+0',
+      trendUp: metrics.pending <= metrics.total / 2,
+    },
+    {
+      id: 'completed',
+      label: '已完成',
+      value: String(metrics.completed),
+      icon: 'checkmark-circle-outline',
+      trend: `+${metrics.completed}`,
+      trendUp: true,
+    },
+    {
+      id: 'overdue',
+      label: '逾期',
+      value: String(metrics.overdue),
+      icon: 'alert-circle-outline',
+      trend: `-${metrics.overdue}`,
+      trendUp: false,
+    },
+    {
+      id: 'efficiency',
+      label: '完成效率',
+      value: `${metrics.efficiency}%`,
+      icon: 'trending-up-outline',
+      trend: metrics.total > 0 ? `+${metrics.efficiency}%` : '+0%',
+      trendUp: metrics.efficiency >= 50,
+    }
+  ];
+
   return (
     <View style={styles.container}>
       {statsData.map((stat) => (
@@ -55,36 +109,36 @@ export default function StatsCards() {
           ]}
         >
           <View style={styles.cardHeader}>
-            <View 
+            <View
               style={[
                 styles.iconContainer,
-                { 
+                {
                   backgroundColor: theme.colors.primary + (theme.dark ? '20' : '10'),
                 }
               ]}
             >
-              <Ionicons 
+              <Ionicons
                 name={stat.icon}
-                size={16} 
+                size={16}
                 color={theme.colors.primary}
               />
             </View>
-            <View 
+            <View
               style={[
                 styles.trendContainer,
                 {
-                  backgroundColor: stat.trendUp 
-                    ? (theme.colors.success || '#10B981') + '20' 
+                  backgroundColor: stat.trendUp
+                    ? (theme.colors.success || '#10B981') + '20'
                     : (theme.colors.destructive || '#EF4444') + '20',
                 }
               ]}
             >
-              <Text 
+              <Text
                 style={[
                   styles.trendText,
                   {
-                    color: stat.trendUp 
-                      ? (theme.colors.success || '#10B981') 
+                    color: stat.trendUp
+                      ? (theme.colors.success || '#10B981')
                       : (theme.colors.destructive || '#EF4444'),
                   }
                 ]}
@@ -93,9 +147,9 @@ export default function StatsCards() {
               </Text>
             </View>
           </View>
-          
+
           <View style={styles.cardContent}>
-            <Text 
+            <Text
               style={[
                 styles.label,
                 { color: theme.colors.mutedForeground || theme.colors.text }
@@ -103,7 +157,7 @@ export default function StatsCards() {
             >
               {stat.label}
             </Text>
-            <Text 
+            <Text
               style={[
                 styles.value,
                 { color: theme.colors.text }
@@ -122,15 +176,16 @@ const styles = StyleSheet.create({
   container: {
     flexDirection: 'row',
     flexWrap: 'wrap',
-    gap: 12,
+    justifyContent: 'space-between',
+    rowGap: 12,
     marginBottom: 24,
   },
   card: {
-    flex: 1,
-    minWidth: '45%',
+    width: '48%',
     padding: 16,
-    borderRadius: 16,
+    borderRadius: 20,
     borderWidth: 1,
+    marginBottom: 12,
   },
   cardHeader: {
     flexDirection: 'row',
@@ -139,25 +194,27 @@ const styles = StyleSheet.create({
     marginBottom: 12,
   },
   iconContainer: {
-    padding: 8,
-    borderRadius: 12,
+    padding: 10,
+    borderRadius: 16,
   },
   trendContainer: {
     flexDirection: 'row',
     alignItems: 'center',
     gap: 4,
-    paddingHorizontal: 8,
-    paddingVertical: 4,
-    borderRadius: 8,
+    paddingHorizontal: 10,
+    paddingVertical: 6,
+    borderRadius: 12,
   },
   trendText: {
     fontSize: 12,
+    fontWeight: '600',
   },
   cardContent: {
-    gap: 4,
+    gap: 6,
   },
   label: {
     fontSize: 12,
+    fontWeight: '500',
   },
   value: {
     fontSize: 24,

--- a/src/components/StatsCards.tsx
+++ b/src/components/StatsCards.tsx
@@ -1,133 +1,212 @@
-import React from 'react';
+import React, { useMemo } from 'react';
 import { View, Text, StyleSheet } from 'react-native';
 import { Ionicons } from '@expo/vector-icons';
 import { useThemeContext } from '../context/ThemeContext';
 
-const statsData = [
-  {
-    id: 'pending',
-    label: '进行中',
-    value: '8',
-    icon: 'time-outline',
-    trend: '+2',
-    trendUp: true
-  },
-  {
-    id: 'completed',
-    label: '已完成',
-    value: '24',
-    icon: 'checkmark-circle-outline',
-    trend: '+5',
-    trendUp: true
-  },
-  {
-    id: 'overdue',
-    label: '逾期',
-    value: '2',
-    icon: 'alert-circle-outline',
-    trend: '-1',
-    trendUp: false
-  },
-  {
-    id: 'efficiency',
-    label: '效率',
-    value: '92%',
-    icon: 'trending-up-outline',
-    trend: '+8%',
-    trendUp: true
-  }
-];
+type TaskCategory = 'pending' | 'completed' | 'overdue' | string;
+type TaskPriority = 'high' | 'medium' | 'low' | string;
 
-export function StatsCards() {
+interface Task {
+  category?: TaskCategory;
+  deadline?: string | Date;
+  priority?: TaskPriority;
+}
+
+interface TaskMetrics {
+  total: number;
+  pending: number;
+  completed: number;
+  overdue: number;
+  efficiency: number;
+}
+
+interface StatsCardsProps {
+  tasks?: Task[];
+}
+
+const getTaskMetrics = (tasks: Task[] = []): TaskMetrics => {
+  if (!Array.isArray(tasks) || tasks.length === 0) {
+    return {
+      total: 0,
+      pending: 0,
+      completed: 0,
+      overdue: 0,
+      efficiency: 0,
+    };
+  }
+
+  const now = new Date();
+
+  const metrics = tasks.reduce(
+    (acc, task) => {
+      const category = task.category;
+
+      if (category === 'completed') {
+        acc.completed += 1;
+      } else if (category === 'pending') {
+        acc.pending += 1;
+      }
+
+      const isOverdue = (() => {
+        if (category === 'overdue') {
+          return true;
+        }
+
+        if (!task.deadline || category === 'completed') {
+          return false;
+        }
+
+        const deadlineDate = new Date(task.deadline);
+        return !Number.isNaN(deadlineDate.getTime()) && deadlineDate < now;
+      })();
+
+      if (isOverdue) {
+        acc.overdue += 1;
+      }
+
+      return acc;
+    },
+    { pending: 0, completed: 0, overdue: 0 }
+  );
+
+  const total = tasks.length;
+  const efficiency = total > 0 ? Math.round((metrics.completed / total) * 100) : 0;
+
+  return {
+    total,
+    pending: metrics.pending,
+    completed: metrics.completed,
+    overdue: metrics.overdue,
+    efficiency,
+  };
+};
+
+const StatsCardsComponent: React.FC<StatsCardsProps> = ({ tasks = [] }) => {
   const { theme } = useThemeContext();
-  
+
+  const metrics = useMemo(() => getTaskMetrics(tasks), [tasks]);
+  const borderColor = theme.colors.cardBorder ?? theme.colors.border;
+  const successColor = theme.colors.success ?? '#10B981';
+  const destructiveColor = theme.colors.destructive ?? '#EF4444';
+
+  const statsData = [
+    {
+      id: 'pending',
+      label: '进行中',
+      value: String(metrics.pending),
+      icon: 'time-outline' as const,
+      trend: metrics.total > 0 ? `+${metrics.pending}` : '+0',
+      trendUp: metrics.pending <= metrics.total / 2,
+    },
+    {
+      id: 'completed',
+      label: '已完成',
+      value: String(metrics.completed),
+      icon: 'checkmark-circle-outline' as const,
+      trend: `+${metrics.completed}`,
+      trendUp: true,
+    },
+    {
+      id: 'overdue',
+      label: '逾期',
+      value: String(metrics.overdue),
+      icon: 'alert-circle-outline' as const,
+      trend: `-${metrics.overdue}`,
+      trendUp: false,
+    },
+    {
+      id: 'efficiency',
+      label: '完成效率',
+      value: `${metrics.efficiency}%`,
+      icon: 'trending-up-outline' as const,
+      trend: metrics.total > 0 ? `+${metrics.efficiency}%` : '+0%',
+      trendUp: metrics.efficiency >= 50,
+    },
+  ];
+
   return (
     <View style={styles.container}>
-      {statsData.map((stat) => (
-        <View
-          key={stat.id}
-          style={[
-            styles.card,
-            {
-              backgroundColor: theme.colors.card,
-              borderColor: theme.colors.cardBorder,
-            }
-          ]}
-        >
-          <View style={styles.cardHeader}>
-            <View 
-              style={[
-                styles.iconContainer,
-                { 
-                  backgroundColor: theme.colors.primary + (theme.id === 'dark' ? '20' : '10'),
-                }
-              ]}
-            >
-              <Ionicons 
-                name={stat.icon as any}
-                size={16} 
-                color={theme.colors.primary}
-              />
-            </View>
-            <View 
-              style={[
-                styles.trendContainer,
-                {
-                  backgroundColor: stat.trendUp 
-                    ? theme.colors.success + '20' 
-                    : theme.colors.destructive + '20',
-                }
-              ]}
-            >
-              <Text 
+      {statsData.map((stat) => {
+        const isTrendUp = stat.trendUp;
+        return (
+          <View
+            key={stat.id}
+            style={[
+              styles.card,
+              {
+                backgroundColor: theme.colors.card,
+                borderColor,
+              },
+            ]}
+          >
+            <View style={styles.cardHeader}>
+              <View
                 style={[
-                  styles.trendText,
+                  styles.iconContainer,
                   {
-                    color: stat.trendUp ? theme.colors.success : theme.colors.destructive,
-                  }
+                    backgroundColor: `${theme.colors.primary}${theme.dark ? '20' : '10'}`,
+                  },
                 ]}
               >
-                {stat.trend}
+                <Ionicons name={stat.icon} size={16} color={theme.colors.primary} />
+              </View>
+              <View
+                style={[
+                  styles.trendContainer,
+                  {
+                    backgroundColor: isTrendUp
+                      ? `${successColor}20`
+                      : `${destructiveColor}20`,
+                  },
+                ]}
+              >
+                <Text
+                  style={[
+                    styles.trendText,
+                    { color: isTrendUp ? successColor : destructiveColor },
+                  ]}
+                >
+                  {stat.trend}
+                </Text>
+              </View>
+            </View>
+
+            <View style={styles.cardContent}>
+              <Text
+                style={[
+                  styles.label,
+                  { color: theme.colors.mutedForeground ?? theme.colors.text },
+                ]}
+              >
+                {stat.label}
               </Text>
+              <Text style={[styles.value, { color: theme.colors.text }]}>{stat.value}</Text>
             </View>
           </View>
-          
-          <View style={styles.cardContent}>
-            <Text 
-              style={[
-                styles.label,
-                { color: theme.colors.mutedForeground }
-              ]}
-            >
-              {stat.label}
-            </Text>
-            <Text 
-              style={[
-                styles.value,
-                { color: theme.colors.foreground }
-              ]}
-            >
-              {stat.value}
-            </Text>
-          </View>
-        </View>
-      ))}
+        );
+      })}
     </View>
   );
-}
+};
+
+export const StatsCards = StatsCardsComponent;
+
+export default StatsCardsComponent;
 
 const styles = StyleSheet.create({
   container: {
     flexDirection: 'row',
     flexWrap: 'wrap',
-    gap: 12,
+    justifyContent: 'space-between',
+    rowGap: 12,
+    marginBottom: 24,
   },
   card: {
-    flex: 1,
-    minWidth: '45%',
+    width: '48%',
     padding: 16,
-    borderRadius: 16,
+    borderRadius: 20,
     borderWidth: 1,
+    marginBottom: 12,
   },
   cardHeader: {
     flexDirection: 'row',
@@ -136,25 +215,27 @@ const styles = StyleSheet.create({
     marginBottom: 12,
   },
   iconContainer: {
-    padding: 8,
-    borderRadius: 12,
+    padding: 10,
+    borderRadius: 16,
   },
   trendContainer: {
     flexDirection: 'row',
     alignItems: 'center',
     gap: 4,
-    paddingHorizontal: 8,
-    paddingVertical: 4,
-    borderRadius: 8,
+    paddingHorizontal: 10,
+    paddingVertical: 6,
+    borderRadius: 12,
   },
   trendText: {
     fontSize: 12,
+    fontWeight: '600',
   },
   cardContent: {
-    gap: 4,
+    gap: 6,
   },
   label: {
     fontSize: 12,
+    fontWeight: '500',
   },
   value: {
     fontSize: 24,

--- a/src/screens/NewHomeScreen.js
+++ b/src/screens/NewHomeScreen.js
@@ -280,7 +280,7 @@ export default function NewHomeScreen({ navigation }) {
           </View>
           
           <View style={styles.content}>
-            <FilterChips 
+            <FilterChips
               tasks={allTasks}
               selectedFilter={currentFilter}
               onFilterChange={(filter) => {
@@ -291,7 +291,7 @@ export default function NewHomeScreen({ navigation }) {
                 }
               }}
             />
-            <StatsCards />
+            <StatsCards tasks={allTasks} />
             
             {filteredOneTimeTasks.length > 0 || filteredRecurringTasks.length > 0 ? (
               <View style={styles.taskSections}>

--- a/src/screens/TestHomeScreen.js
+++ b/src/screens/TestHomeScreen.js
@@ -40,12 +40,12 @@ export default function TestHomeScreen({ navigation }) {
           </View>
           
           <View style={styles.content}>
-            <FilterChips 
+            <FilterChips
               tasks={sampleTasks}
               selectedFilter={currentFilter}
               onFilterChange={setCurrentFilter}
             />
-            <StatsCards />
+            <StatsCards tasks={sampleTasks} />
             
             <Text style={[styles.title, { color: theme.colors.text }]}>
               Test Home Screen


### PR DESCRIPTION
## Summary
- derive default filter chips from the task data so the React Native view mirrors the web layout and labels
- tune the filter chip and stats card styling (spacing, typography, and badge treatments) to match the Figma/Web implementation
- adjust the stats cards grid sizing so the two-column layout renders consistently on iOS

## Testing
- npm run start -- --help

------
https://chatgpt.com/codex/tasks/task_e_68d16e207ef88328b323cd33ebed61ab